### PR TITLE
Setup examples-to-documentation conversion using Literate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /benchmark/*.json
 /docs/build
 /docs/site
+/docs/src
 Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -21,8 +21,9 @@ julia = "1"
 [extras]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+LiterateTest = "d77d25b0-90d3-4a16-b10a-412a9d48f625"
 MicroCollections = "128add7d-3638-4c79-886c-908ea0c25c34"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["BangBang", "Documenter", "MicroCollections", "Test"]
+test = ["BangBang", "Documenter", "LiterateTest", "MicroCollections", "Test"]

--- a/README.md
+++ b/README.md
@@ -129,6 +129,34 @@ julia> @floop for (i, v) in pairs([0, 1, 3, 2]), (j, w) in pairs([3, 1, 5])
 (5, 1, 3)
 ```
 
+When reading code with `@reduce() do`, a quick way to understand it is
+to mentally comment out the line with `@reduce() do` and the
+corresponding `end`.  To get a full picture, move the initialization
+parts (in the above example, `dmax = -1`, `imax = 0`, and `jmax = 0`)
+to outside `for` loop:
+
+```julia
+julia> let
+           dmax = -1  # -+
+           imax = 0   #  | initializers
+           jmax = 0   # -+
+           for (i, v) in pairs([0, 1, 3, 2]), (j, w) in pairs([3, 1, 5])
+               d = abs(v - w)
+               if isless(dmax, d)  # -+
+                   dmax = d        #  | `do` block body
+                   imax = i        #  |
+                   jmax = j        #  |
+               end                 # -+
+           end
+           (dmax, imax, jmax)
+       end
+(5, 1, 3)
+```
+
+This exact transformation is used for defining the sequential
+basecase.  Consecutive basecases are combined using the code in the
+`do` block body.
+
 Control flow syntaxes (see below) such as `continue`, `break`,
 `return`, and `@goto` work with parallel loops:
 

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -124,7 +124,7 @@ version = "2.6.0"
 
 [[LiterateTest]]
 deps = ["Test"]
-git-tree-sha1 = "2a492dfdedc7ec97e8c1e514bfbc5b8630266032"
+git-tree-sha1 = "9645e4d2d6ae3e959c736d64ec883864be03614c"
 repo-rev = "master"
 repo-url = "https://github.com/tkf/LiterateTest.jl.git"
 uuid = "d77d25b0-90d3-4a16-b10a-412a9d48f625"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -124,9 +124,11 @@ version = "2.6.0"
 
 [[LiterateTest]]
 deps = ["Test"]
-git-tree-sha1 = "ec424cc76e299ef19e1aa1dad9ff25f5e7ad52a0"
+git-tree-sha1 = "2a492dfdedc7ec97e8c1e514bfbc5b8630266032"
+repo-rev = "master"
+repo-url = "https://github.com/tkf/LiterateTest.jl.git"
 uuid = "d77d25b0-90d3-4a16-b10a-412a9d48f625"
-version = "0.1.2"
+version = "0.1.3-DEV"
 
 [[LoadAllPackages]]
 deps = ["Pkg"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
+LiterateTest = "d77d25b0-90d3-4a16-b10a-412a9d48f625"
+LoadAllPackages = "b37bcd2d-1570-475d-a8c6-9b4fae6d0ba9"

--- a/examples/howto/parallel.jl
+++ b/examples/howto/parallel.jl
@@ -1,0 +1,44 @@
+# # How to write _X_ in parallel.
+
+# !!! warning
+#
+#     This page is still work-in-progress.
+
+# ## In-place mutation
+#
+# Mutable containers can be allocated in the `init` expressions
+# (`zeros(3)` in the example below):
+
+@test begin
+    @floop for x in 1:10
+        xs = [x, 2x, 3x]
+        @reduce() do (ys = zeros(3); xs)
+            ys .+= xs
+        end
+    end
+    ys
+end == [55, 110, 165]
+
+# Mutating objects allocated in the `init` expressions is not data
+# race because each basecase "owns" such mutable objects.  However, it
+# is incorrect to mutate objects created outside `init` expressions.
+#
+# !!! note
+#
+#     Technically, it is correct to mutate objects in the loop body if
+#     the objects are protected by a lock.  However, it means that the
+#     code block protected by the lock can be executed by a single
+#     task.  For efficient data parallel loops, it is highly
+#     recommended to use **non**-thread-safe data collection (i.e., no
+#     lock) and construct the `@reduce` block that efficiently merge
+#     two mutable objects.
+
+# ### INCORRECT EXAMPLE
+
+ys0 = zeros(3)
+@floop for x in 1:10
+    xs = [x, 2x, 3x]
+    @reduce() do (ys = ys0; xs)
+        ys .+= xs
+    end
+end

--- a/examples/howto/parallel.jl
+++ b/examples/howto/parallel.jl
@@ -35,6 +35,9 @@ end == [55, 110, 165]
 
 # ### INCORRECT EXAMPLE
 
+# This example has data race because the array `ys0` is shared across
+# all base cases and mutated in parallel.
+
 ys0 = zeros(3)
 @floop for x in 1:10
     xs = [x, 2x, 3x]

--- a/examples/howto/parallel.jl
+++ b/examples/howto/parallel.jl
@@ -1,5 +1,9 @@
 # # How to write _X_ in parallel.
 
+using FLoops
+
+using Test                                                             #src
+
 # !!! warning
 #
 #     This page is still work-in-progress.

--- a/examples/reference/reduction.jl
+++ b/examples/reference/reduction.jl
@@ -1,0 +1,35 @@
+# # Parallelizable reduction using `@reduce`
+
+# !!! warning
+#
+#     This page is still work-in-progress.
+
+using FLoops
+
+using LiterateTest                                                     #src
+using Test                                                             #src
+
+# ## [`@reduce() do ... end` syntax](@id ref-reduce-do)
+
+@test begin
+    @floop for x in 1:10
+        y = 2x
+        @reduce() do (acc; y)
+            acc + y
+        end
+    end
+    acc
+end == 110
+
+# ### Argument symbols must be unique within a `@reduce` block
+
+@testset_error @eval try
+    @floop for x in 1:10
+        @reduce() do (a; x), (b; x)
+            a += x
+            b *= x
+        end
+    end
+catch err
+    @test err isa Exception
+end

--- a/examples/reference/reduction.jl
+++ b/examples/reference/reduction.jl
@@ -34,16 +34,16 @@ catch err
     @test err isa Exception
 end
 
-## TODO: @reduce(a += x, b *= x) should work
-##
-## # Note that `op=` syntax does not have this restriction:
-##
-## @test begin
-##     @floop for x in 1:10
-##         @reduce(a += x, b *= x)
-##     end
-##     (a, b)
-## end == (55, 3628800)
+#src TODO: @reduce(a += x, b *= x) should work
+#src
+#src # Note that `op=` syntax does not have this restriction:
+#src
+#src @test begin
+#src     @floop for x in 1:10
+#src         @reduce(a += x, b *= x)
+#src     end
+#src     (a, b)
+#src end == (55, 3628800)
 
 # The argument should be manually duplicated when using the same
 # variable that would be merged into multiple accumulators:

--- a/examples/reference/reduction.jl
+++ b/examples/reference/reduction.jl
@@ -34,14 +34,16 @@ catch err
     @test err isa Exception
 end
 
-# Note that `op=` syntax does not have this restriction:
-
-@test begin
-    @floop for x in 1:10
-        @reduce(a += x, b *= x)
-    end
-    (a, b)
-end == (55, 3628800)
+## TODO: @reduce(a += x, b *= x) should work
+##
+## # Note that `op=` syntax does not have this restriction:
+##
+## @test begin
+##     @floop for x in 1:10
+##         @reduce(a += x, b *= x)
+##     end
+##     (a, b)
+## end == (55, 3628800)
 
 # The argument should be manually duplicated when using the same
 # variable that would be merged into multiple accumulators:

--- a/examples/reference/reduction.jl
+++ b/examples/reference/reduction.jl
@@ -15,7 +15,7 @@ using Test                                                             #src
     @floop for x in 1:10
         y = 2x
         @reduce() do (acc; y)
-            acc + y
+            acc += y
         end
     end
     acc

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -134,16 +134,17 @@ function analyze_rf_args(ex::Expr)
     inputs = []
     for arg in ex.args
         @match arg begin
-            Expr(:block, acc_init, ::LineNumberNode, x) => begin
-                push!(inputs, x)
-                @match acc_init begin
-                    Expr(:(=), a, i) => begin
-                        push!(accs, a)
-                        push!(inits, i)
+            Expr(:block, acc_init, x) || Expr(:block, acc_init, ::LineNumberNode, x) =>
+                begin
+                    push!(inputs, x)
+                    @match acc_init begin
+                        Expr(:(=), a, i) => begin
+                            push!(accs, a)
+                            push!(inits, i)
+                        end
+                        a => push!(accs, a)
                     end
-                    a => push!(accs, a)
                 end
-            end
             Expr(:tuple, a, x) => begin
                 throw(ArgumentError("got `($a, $x)` use `($a; $x)` instead"))
             end

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -242,6 +242,9 @@ function as_parallel_loop(rf_arg, coll, body0::Expr, simd, executor)
         push!(all_rf_inputs, inputs)
         verify_unique_symbols(accs, "accumulator")
         verify_unique_symbols(inputs, "input")
+        # TODO: input symbols just have to be unique within a
+        # `@reduce` block.  This restriction (unique across all
+        # `@reduce`) can be removed.
         initializers = [:($a = $x) for (a, x) in zip(accs, inputs)]
         function rf_body_with_init(pre_updates = [])
             quote

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -124,7 +124,7 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[LiterateTest]]
 deps = ["Test"]
-git-tree-sha1 = "2a492dfdedc7ec97e8c1e514bfbc5b8630266032"
+git-tree-sha1 = "9645e4d2d6ae3e959c736d64ec883864be03614c"
 repo-rev = "master"
 repo-url = "https://github.com/tkf/LiterateTest.jl.git"
 uuid = "d77d25b0-90d3-4a16-b10a-412a9d48f625"

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -124,7 +124,7 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[LiterateTest]]
 deps = ["Test"]
-git-tree-sha1 = "c4f78d3353e17381d53e829439b5d1c521113690"
+git-tree-sha1 = "2a492dfdedc7ec97e8c1e514bfbc5b8630266032"
 repo-rev = "master"
 repo-url = "https://github.com/tkf/LiterateTest.jl.git"
 uuid = "d77d25b0-90d3-4a16-b10a-412a9d48f625"

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -122,6 +122,14 @@ uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 deps = ["Libdl"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
+[[LiterateTest]]
+deps = ["Test"]
+git-tree-sha1 = "c4f78d3353e17381d53e829439b5d1c521113690"
+repo-rev = "master"
+repo-url = "https://github.com/tkf/LiterateTest.jl.git"
+uuid = "d77d25b0-90d3-4a16-b10a-412a9d48f625"
+version = "0.1.3-DEV"
+
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 

--- a/test/environments/main/Project.toml
+++ b/test/environments/main/Project.toml
@@ -2,6 +2,7 @@
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FLoops = "cc61a311-1640-44b5-9fba-1b764f453329"
+LiterateTest = "d77d25b0-90d3-4a16-b10a-412a9d48f625"
 MicroCollections = "128add7d-3638-4c79-886c-908ea0c25c34"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Transducers = "28d57a85-8fef-5791-bfe6-a80928e7c999"

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -1,0 +1,23 @@
+module TestExamples
+
+using Test
+
+examplesbase = joinpath(dirname(@__DIR__), "examples")
+examples = []
+for (root, _, files) in walkdir(examplesbase)
+    for name in files
+        endswith(name, ".jl") || continue
+        relname = joinpath(relpath(root, examplesbase), name)
+        push!(examples, relname => joinpath(root, name))
+    end
+end
+
+const modules = Dict()
+
+@testset "$relname" for (relname, fullpath) in examples
+    modules[relname] = m = Module()
+    @eval m using LiterateTest.AssertAsTest: @assert
+    Base.include(m, fullpath)
+end
+
+end  # module


### PR DESCRIPTION
- [x] Release LiterateTest 0.1.3

## Commit Message
Setup examples-to-documentation conversion using Literate (#44)

This patch sets up examples-to-documentation conversion using
Literate.jl and LiterateTest.jl.  It also adds a few examples (e.g.,
one from #41).