### PR TITLE
Fix test failures in Julia 1.0 (pre-1.3)

### DIFF
--- a/.github/workflows/check-xfail.yml
+++ b/.github/workflows/check-xfail.yml
@@ -1,0 +1,31 @@
+name: Check xfail
+
+on:
+  pull_request:
+
+jobs:
+  xfail:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        julia-version: ['^1']
+      fail-fast: false
+    name: Test xfail Julia ${{ matrix.julia-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: tkf/merge-xfail-branch@v1
+        id: merge-xfail-branch
+
+      - name: Setup julia
+        if: ${{ steps.merge-xfail-branch.outputs.need_xfail == 'yes' }}
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+
+      - run: julia -e 'using Pkg; pkg"add Run@0.1"'
+        if: ${{ steps.merge-xfail-branch.outputs.need_xfail == 'yes' }}
+
+      - run: julia -e 'using Run; Run.test(project = "test/environments/main", xfail = true)'
+        if: ${{ steps.merge-xfail-branch.outputs.need_xfail == 'yes' }}
+        env:
+          JULIA_NUM_THREADS: '2'


### PR DESCRIPTION
## Commit Message
Fix test failures in Julia 1.0 (pre-1.3) (#75)

In pre-1.3, `ReentrantLock` was not thread-compatible. Let's use atomics
to make it work for any versions (including hypothetical future Julia
versions with task migration support).