### PR TITLE
Fix unbound_rhs

### DIFF
--- a/src/macro.jl
+++ b/src/macro.jl
@@ -283,7 +283,7 @@ function _global_rhs(ex::Expr)
     @match ex begin
         Expr(:(=), _, rhs) => _global_rhs(rhs)
         Expr(:tuple, _..., Expr(:(=), _, rhs)) => _global_rhs(rhs)
-        Expr(_, args...) => mapreduce(_global_rhs, vcat, args)
+        Expr(_, args...) => mapfoldl(_global_rhs, append!, args; init = Symbol[])
     end
 end
 

--- a/test/test_ast_tools.jl
+++ b/test/test_ast_tools.jl
@@ -1,0 +1,15 @@
+module TestAstTools
+
+using FLoops: unbound_rhs
+using Test
+
+@testset "unbound_rhs" begin
+    @test unbound_rhs(:a) == [:a]
+    @test unbound_rhs(:(let x = 1; (x, y); end)) == [:y]
+    @test unbound_rhs(quote end) == []
+    @test unbound_rhs(quote () end) == []
+    @test unbound_rhs(quote [] end) == []
+    @test unbound_rhs(nothing) == []
+end
+
+end  # module


### PR DESCRIPTION
## Commit Message
Fix unbound_rhs (#78)

This patch fixes errors like this

    julia> @floop for x in 1:2
               @init p = []
           end
    ERROR: LoadError: ArgumentError: reducing over an empty collection is not allowed

which is caused by `unbound_rhs(:([]))`.