### PR TITLE
Don't leak private variables from at-init

### DIFF
--- a/test/test_reduce.jl
+++ b/test/test_reduce.jl
@@ -256,6 +256,21 @@ end
     end
 end
 
+function init_is_private(xs, ex = nothing)
+    @floop ex for x in xs
+        @init p = []
+        push!(p, x)
+        y = pop!(p)
+        @reduce s += y
+    end
+    return (sum = s, isdefined_p = @isdefined(p))
+end
+
+@testset "@init is private" begin
+    @test init_is_private(1:10) == (sum = sum(1:10), isdefined_p = false)
+    @test init_is_private(1:10, SequentialEx()) == (sum = sum(1:10), isdefined_p = false)
+end
+
 @testset "unprocessed @reduce" begin
     err = try
         @reduce(s += y, p *= y)


### PR DESCRIPTION
It is expensive to ensure that the private variables exist in the
outer scope in distributed setting.  So, let's make sure private
objects stay private.