### PR TITLE
Don't throw `HasBoxedVariableError` by default

### DIFF
--- a/docs/src/reference/api.md
+++ b/docs/src/reference/api.md
@@ -31,3 +31,9 @@ See also:
 * [`Transducers.ThreadedEx`](https://juliafolds.github.io/Transducers.jl/dev/reference/manual/#Transducers.ThreadedEx)
 * [`Transducers.DistributedEx`](https://juliafolds.github.io/Transducers.jl/dev/reference/manual/#Transducers.DistributedEx)
 * [How is a parallel `@floop` executed? What is the scheduling strategy?](@ref faq-exeuctor)
+
+## `FLoops.assistant`
+
+```@docs
+FLoops.assistant
+```

--- a/src/checkboxes.jl
+++ b/src/checkboxes.jl
@@ -10,8 +10,93 @@ else
     const has_boxed_variables = has_boxed_variables_g
 end
 
-function verify_no_boxes(f::F) where {F}
-    has_boxed_variables(f) && throw(HasBoxedVariableError(f))
+function verify_no_boxes(f::F, context) where {F}
+    has_boxed_variables(f) && handle_boxed_variables(f, context())
+    return
+end
+
+baremodule AssistantMode
+using Base: @enum, UInt8
+@enum Kind::UInt8 begin
+    ignore
+    warn
+    warn_always
+    error
+end
+end
+
+const ASSISTANT_MODE = Ref(AssistantMode.warn)
+
+struct SetAssistantResult
+    old::AssistantMode.Kind
+    new::AssistantMode.Kind
+end
+
+"""
+    FLoops.assistant(mode::Symbol)
+    FLoops.assistant(enable::Bool)
+
+Set assistant mode; i.e., what to do when FLoops.jl finds a problematic usage
+pattern.
+
+Assistant modes:
+
+* `:ignore`: do nothing
+* `:warn`: print warning once
+* `:warn_always`: print warning always
+* `:error`: throw an error
+
+`FLoops.assistant(false)` is equivalent to `FLoops.assistant(:ignore)` and
+`FLoops.assistant(true)` is equivalent to `FLoops.assistant(:warn)`.
+"""
+assistant
+function assistant(mode::Symbol)
+    m = nothing
+    if isdefined(AssistantMode, mode)
+        m = getproperty(AssistantMode, mode)
+    end
+    if !(m isa AssistantMode.Kind)
+        error(
+            "invalid mode: ",
+            mode,
+            " (must be one of `:ignore`, `:warn`, `:warn_always`, and `:error`)",
+        )
+    end
+    p = ASSISTANT_MODE[]
+    ASSISTANT_MODE[] = m
+    return SetAssistantResult(p, m)
+end
+
+assistant(enable::Bool) = enable ? assistant(:warn) : assistant(:ignore)
+
+function Base.show(io::IO, ::MIME"text/plain", result::SetAssistantResult)
+    printstyled(io, "FLoops.assistant"; color = :blue)
+    print(io, ":")
+    print(io, "\n  old mode: ", result.old)
+    print(io, "\n  new mode: ", result.new)
+end
+
+function handle_boxed_variables(f, context)
+    mode = ASSISTANT_MODE[]
+    mode == AssistantMode.ignore && return
+
+    err = HasBoxedVariableError(f)
+    if mode == AssistantMode.error
+        throw(err)
+    elseif mode == AssistantMode.warn || mode == AssistantMode.warn_always
+        ctx = context.ctx::MacroContext
+        @warn(
+            "Correctness and/or performance problem detected",
+            error = err,
+            _module = ctx.module_,
+            _file = string(something(ctx.source.file, "none")),
+            _line = ctx.source.line,
+            _id = Symbol(context.id, mode == AssistantMode.warn ? :_once : :_always),
+            maxlog = mode == AssistantMode.warn ? 1 : nothing,
+        )
+    else
+        error("unknown mode: ", mode)
+    end
     return
 end
 
@@ -65,6 +150,18 @@ function Base.showerror(io::IO, err::HasBoxedVariableError)
         color = :light_black,
     )
     # "To ignore this error, pass `allow_boxing = Val(true)` to the executor."
+
+    println(io)
+    printstyled(io, "NOTE:", bold = true, color = :light_black)
+    printstyled(
+        io,
+        " To disable this ",
+        ASSISTANT_MODE[] == AssistantMode.error ? "error" : "warning",
+        ", call `";
+        color = :light_black,
+    )
+    printstyled(io, "FLoops.assistant(false)"; bold = true, color = :light_black)
+    printstyled(io, "`."; color = :light_black)
 end
 
 function _make_closure_with_a_box()
@@ -94,5 +191,5 @@ end
     const _verify_no_boxes = verify_no_boxes
 else
     # Since `Core.Box` is internal, we can't rely on that it exists.
-    const _verify_no_boxes = identity
+    const _verify_no_boxes = donothing
 end


### PR DESCRIPTION
Add `FLoops.assistant` for controlling how it's handled.